### PR TITLE
Implement youtube

### DIFF
--- a/src/Youtube2Mp3.Core/Extensions/StringExtensions.cs
+++ b/src/Youtube2Mp3.Core/Extensions/StringExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Youtube2Mp3.Core.Extensions
+{
+    public static class StringExtensions
+    {
+        public static string RemoveIllegalPathCharacters(this string path)
+        {
+            string regexSearch = $"{Path.GetInvalidFileNameChars().ToString()}{Path.GetInvalidPathChars().ToString()}";
+            var r = new Regex(string.Format("[{0}]", Regex.Escape(regexSearch)));
+            return r.Replace(path, "");
+        }
+    }
+}

--- a/src/Youtube2Mp3.Core/Services/IDownloadService.cs
+++ b/src/Youtube2Mp3.Core/Services/IDownloadService.cs
@@ -4,6 +4,6 @@ namespace Youtube2Mp3.Core.Services
 {
     public interface IDownloadService
     {
-        void DownloadMedia(Stream stream);
+        void DownloadMedia(Stream stream, string filePath);
     }
 }

--- a/src/Youtube2Mp3.Core/Services/IDownloadService.cs
+++ b/src/Youtube2Mp3.Core/Services/IDownloadService.cs
@@ -1,0 +1,9 @@
+﻿using System.IO;
+
+namespace Youtube2Mp3.Core.Services
+{
+    public interface IDownloadService
+    {
+        void DownloadMedia(Stream stream);
+    }
+}

--- a/src/Youtube2Mp3.Core/Services/IStreamRepository.cs
+++ b/src/Youtube2Mp3.Core/Services/IStreamRepository.cs
@@ -1,0 +1,11 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Youtube2Mp3.Core.Entities;
+
+namespace Youtube2Mp3.Core.Services
+{
+    public interface IStreamRepository
+    {
+        Task<Stream> GetStreamOfTrack(Track track);
+    }
+}

--- a/src/Youtube2Mp3.IOC/IOCExtention.cs
+++ b/src/Youtube2Mp3.IOC/IOCExtention.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using System;
 using Youtube2Mp3.Core.Services;
 using Youtube2Mp3.Spotify;
+using Youtube2Mp3.Youtube;
 
 namespace Youtube2Mp3.IOC
 {
@@ -11,6 +11,7 @@ namespace Youtube2Mp3.IOC
             => services.AddSingleton<ITrackRespository, SpotifyTrackRepository>();
 
         public static IServiceCollection UseYoutube(this IServiceCollection services)
-            => throw new NotImplementedException();
+            => services.AddSingleton<IStreamRepository, YoutubeStreamRepository>()
+                       .AddSingleton<IDownloadService, YoutubeStreamRepository>();
     }
 }

--- a/src/Youtube2Mp3.IOC/Youtube2Mp3.IOC.csproj
+++ b/src/Youtube2Mp3.IOC/Youtube2Mp3.IOC.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Youtube2Mp3.Core\Youtube2Mp3.Core.csproj" />
     <ProjectReference Include="..\Youtube2Mp3.Spotify\Youtube2Mp3.Spotify.csproj" />
+    <ProjectReference Include="..\Youtube2Mp3.Youtube\Youtube2Mp3.Youtube.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Youtube2Mp3.Youtube/YoutubeStreamRepository.cs
+++ b/src/Youtube2Mp3.Youtube/YoutubeStreamRepository.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Youtube2Mp3.Core.Entities;
+using Youtube2Mp3.Core.Services;
+using YoutubeExplode;
+using YoutubeExplode.Models.MediaStreams;
+
+namespace Youtube2Mp3.Youtube
+{
+    public class YoutubeStreamRepository : IStreamRepository, IDownloadService
+    {
+        private YoutubeClient _client;
+
+        public YoutubeStreamRepository()
+        {
+            if (_client == null)
+            {
+                _client = new YoutubeClient();
+            }
+        }
+
+        public async Task<Stream> GetStreamOfTrack(Track track)
+        {
+            var stream = new MemoryStream();
+
+            var streamInfoSet = await _client.GetVideoMediaStreamInfosAsync("");
+            var streamInfo = streamInfoSet.Audio.WithHighestBitrate();
+
+            var mediaStream = await _client.GetMediaStreamAsync(streamInfo);
+            mediaStream.CopyTo(stream);
+
+            return stream;
+        }
+
+        public void DownloadMedia(Stream stream)
+        {
+            /*using (var progress = new ProgressBar())
+            {
+                _client.DownloadMediaStreamAsync(stream, $"{fileName}.mp3", progress);
+            }*/
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Youtube2Mp3.Youtube/YoutubeStreamRepository.cs
+++ b/src/Youtube2Mp3.Youtube/YoutubeStreamRepository.cs
@@ -33,11 +33,11 @@ namespace Youtube2Mp3.Youtube
             return stream;
         }
 
-        public void DownloadMedia(Stream stream)
+        public void DownloadMedia(Stream stream, string filePath)
         {
             /*using (var progress = new ProgressBar())
             {
-                _client.DownloadMediaStreamAsync(stream, $"{fileName}.mp3", progress);
+                _client.DownloadMediaStreamAsync(stream, $"{filePath}/{fileName}.mp3", progress);
             }*/
             throw new NotImplementedException();
         }

--- a/src/Youtube2Mp3.sln
+++ b/src/Youtube2Mp3.sln
@@ -15,8 +15,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Youtube2Mp3.Tests", "Youtub
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Youtube2Mp3.Youtube", "Youtube2Mp3.Youtube\Youtube2Mp3.Youtube.csproj", "{DC7B0221-F8F5-41AA-A7DF-A03B2CD9362E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Youtube2Mp3.FFmpeg", "FFmpeg\Youtube2Mp3.FFmpeg.csproj", "{032582ED-B7E7-402F-9F36-8D5337620033}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -99,18 +97,6 @@ Global
 		{DC7B0221-F8F5-41AA-A7DF-A03B2CD9362E}.Release|x64.Build.0 = Release|Any CPU
 		{DC7B0221-F8F5-41AA-A7DF-A03B2CD9362E}.Release|x86.ActiveCfg = Release|Any CPU
 		{DC7B0221-F8F5-41AA-A7DF-A03B2CD9362E}.Release|x86.Build.0 = Release|Any CPU
-		{032582ED-B7E7-402F-9F36-8D5337620033}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{032582ED-B7E7-402F-9F36-8D5337620033}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{032582ED-B7E7-402F-9F36-8D5337620033}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{032582ED-B7E7-402F-9F36-8D5337620033}.Debug|x64.Build.0 = Debug|Any CPU
-		{032582ED-B7E7-402F-9F36-8D5337620033}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{032582ED-B7E7-402F-9F36-8D5337620033}.Debug|x86.Build.0 = Debug|Any CPU
-		{032582ED-B7E7-402F-9F36-8D5337620033}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{032582ED-B7E7-402F-9F36-8D5337620033}.Release|Any CPU.Build.0 = Release|Any CPU
-		{032582ED-B7E7-402F-9F36-8D5337620033}.Release|x64.ActiveCfg = Release|Any CPU
-		{032582ED-B7E7-402F-9F36-8D5337620033}.Release|x64.Build.0 = Release|Any CPU
-		{032582ED-B7E7-402F-9F36-8D5337620033}.Release|x86.ActiveCfg = Release|Any CPU
-		{032582ED-B7E7-402F-9F36-8D5337620033}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Youtube2Mp3.sln
+++ b/src/Youtube2Mp3.sln
@@ -11,9 +11,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Youtube2Mp3.ConsoleUi", "Yo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Youtube2Mp3.IOC", "Youtube2Mp3.IOC\Youtube2Mp3.IOC.csproj", "{7F6170FA-EBFB-47B4-B7C4-35A8B9202044}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Youtube2Mp3.Tests", "Youtube2Mp3.Tests\Youtube2Mp3.Tests.csproj", "{8AEFFD59-D11D-45A2-92DD-F9BB1BF5AC3D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Youtube2Mp3.Tests", "Youtube2Mp3.Tests\Youtube2Mp3.Tests.csproj", "{8AEFFD59-D11D-45A2-92DD-F9BB1BF5AC3D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Youtube2Mp3.Youtube", "Youtube2Mp3.Youtube\Youtube2Mp3.Youtube.csproj", "{DC7B0221-F8F5-41AA-A7DF-A03B2CD9362E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Youtube2Mp3.Youtube", "Youtube2Mp3.Youtube\Youtube2Mp3.Youtube.csproj", "{DC7B0221-F8F5-41AA-A7DF-A03B2CD9362E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Youtube2Mp3.FFmpeg", "FFmpeg\Youtube2Mp3.FFmpeg.csproj", "{032582ED-B7E7-402F-9F36-8D5337620033}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -97,6 +99,18 @@ Global
 		{DC7B0221-F8F5-41AA-A7DF-A03B2CD9362E}.Release|x64.Build.0 = Release|Any CPU
 		{DC7B0221-F8F5-41AA-A7DF-A03B2CD9362E}.Release|x86.ActiveCfg = Release|Any CPU
 		{DC7B0221-F8F5-41AA-A7DF-A03B2CD9362E}.Release|x86.Build.0 = Release|Any CPU
+		{032582ED-B7E7-402F-9F36-8D5337620033}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{032582ED-B7E7-402F-9F36-8D5337620033}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{032582ED-B7E7-402F-9F36-8D5337620033}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{032582ED-B7E7-402F-9F36-8D5337620033}.Debug|x64.Build.0 = Debug|Any CPU
+		{032582ED-B7E7-402F-9F36-8D5337620033}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{032582ED-B7E7-402F-9F36-8D5337620033}.Debug|x86.Build.0 = Debug|Any CPU
+		{032582ED-B7E7-402F-9F36-8D5337620033}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{032582ED-B7E7-402F-9F36-8D5337620033}.Release|Any CPU.Build.0 = Release|Any CPU
+		{032582ED-B7E7-402F-9F36-8D5337620033}.Release|x64.ActiveCfg = Release|Any CPU
+		{032582ED-B7E7-402F-9F36-8D5337620033}.Release|x64.Build.0 = Release|Any CPU
+		{032582ED-B7E7-402F-9F36-8D5337620033}.Release|x86.ActiveCfg = Release|Any CPU
+		{032582ED-B7E7-402F-9F36-8D5337620033}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Changes

- Yt2Mp3.FFmpeg is currently not needed, and thus not implemented.
- Also adds a string extension (RemoveIllegalPathCharacters).
- Two abstractions in `.Core` (IDownloadService, IStreamRepository).

## Further explanation

`IStreamRepository` has a `GetStreamFromTrack(Track track)` signature.
`IDownloadService` has a `DownloadMedia(Stream stream)` signature.

`YoutubeStreamRepository` implements both `IDownloadService` and `IStreamRepository`

## Additional Information

Made a pull request since I'm not 100% sure and wanted your input.

Your idea:
> [Core]
>    - ITrackRepositry (returns a playlist in the form of IEnumerbale<Track>)
>    - IStreamRepository (Takes a single Track and returns the stream for that track Video or Audio, doesn't really matter) 
> [YT2MP3.Spotify]
>    - SpotifyTrackRepositry (Implements ITrackRepository)
> [YT2MP3.Youtube]
>    - YoutubeStreamRepository (Implements IStreamRepository)
> [YT2MP3.FFMPEG]
>    - FfmpegStreamRepository (Implements IStreamRepository)
