### PR TITLE
Upgrade to C# 8 with Nullable reference types

### DIFF
--- a/src/Youtube2Mp3.ConsoleUi/IOC/Setup.cs
+++ b/src/Youtube2Mp3.ConsoleUi/IOC/Setup.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Youtube2Mp3.ConsoleUi.Services;
-using Youtube2Mp3.Core.Services;
 using Youtube2Mp3.IOC;
 using System;
 

--- a/src/Youtube2Mp3.ConsoleUi/Services/YoutubeUI.cs
+++ b/src/Youtube2Mp3.ConsoleUi/Services/YoutubeUI.cs
@@ -17,6 +17,7 @@ namespace Youtube2Mp3.ConsoleUi.Services
         {
             _trackRespository = trackRespository;
             _downloadService = downloadService;
+            _streamRepository = streamRepository;
             _trackRespository.InitializeSpotifyAuth(
                 Environment.GetEnvironmentVariable("SPOTIFY_CLIENT_ID"),
                 Environment.GetEnvironmentVariable("SPOTIFY_CLIENT_SECRET")

--- a/src/Youtube2Mp3.ConsoleUi/Services/YoutubeUI.cs
+++ b/src/Youtube2Mp3.ConsoleUi/Services/YoutubeUI.cs
@@ -17,7 +17,10 @@ namespace Youtube2Mp3.ConsoleUi.Services
         {
             _trackRespository = trackRespository;
             _downloadService = downloadService;
-            _trackRespository.InitializeSpotifyAuth("DO NOT POST", "THIS INFO TO GITHUB");
+            _trackRespository.InitializeSpotifyAuth(
+                Environment.GetEnvironmentVariable("SPOTIFY_CLIENT_ID"),
+                Environment.GetEnvironmentVariable("SPOTIFY_CLIENT_SECRET")
+            );
         }
 
         public async Task SearchYoutubeTest()

--- a/src/Youtube2Mp3.ConsoleUi/Youtube2Mp3.ConsoleUi.csproj
+++ b/src/Youtube2Mp3.ConsoleUi/Youtube2Mp3.ConsoleUi.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Youtube2Mp3.Core/Entities/YoutubeTrack.cs
+++ b/src/Youtube2Mp3.Core/Entities/YoutubeTrack.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Youtube2Mp3.Core.Entities
 {

--- a/src/Youtube2Mp3.Core/Entities/YoutubeTrack.cs
+++ b/src/Youtube2Mp3.Core/Entities/YoutubeTrack.cs
@@ -5,6 +5,7 @@ namespace Youtube2Mp3.Core.Entities
     public class YoutubeTrack : Track
     {
         public string Id { get; private set; }
+
         public YoutubeTrack(string title, IEnumerable<string> authors, int durationMilliSeconds, string id) : base(title, authors, durationMilliSeconds)
         {
             Id = id;

--- a/src/Youtube2Mp3.Core/Extensions/TrackFormatExtensions.cs
+++ b/src/Youtube2Mp3.Core/Extensions/TrackFormatExtensions.cs
@@ -17,10 +17,9 @@ namespace Youtube2Mp3.Core.Extensions
         {
             var author = track.Authors.FirstOrDefault();
 
-            if (string.IsNullOrEmpty(author))
-                return $"{track.Title}".RemoveIllegalPathCharacters();
-            else
-                return $"{author} - {track.Title}".RemoveIllegalPathCharacters();
+            return string.IsNullOrEmpty(author)
+             ? $"{track.Title}".RemoveIllegalPathCharacters()
+             : $"{author} - {track.Title}".RemoveIllegalPathCharacters();
         }
     }
 }

--- a/src/Youtube2Mp3.Core/Youtube2Mp3.Core.csproj
+++ b/src/Youtube2Mp3.Core/Youtube2Mp3.Core.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/src/Youtube2Mp3.IOC/Youtube2Mp3.IOC.csproj
+++ b/src/Youtube2Mp3.IOC/Youtube2Mp3.IOC.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Youtube2Mp3.Spotify/Entities/SpotifyAuth.cs
+++ b/src/Youtube2Mp3.Spotify/Entities/SpotifyAuth.cs
@@ -2,7 +2,7 @@
 {
     public class SpotifyAuth
     {
-        public string ClientId { get; set; }
-        public string ClientSecret { get; set; }
+        public string ClientId { get; set; } = string.Empty;
+        public string ClientSecret { get; set; } = string.Empty;
     }
 }

--- a/src/Youtube2Mp3.Spotify/Extensions/SpotifyClientExtensions.cs
+++ b/src/Youtube2Mp3.Spotify/Extensions/SpotifyClientExtensions.cs
@@ -8,7 +8,7 @@ namespace Youtube2Mp3.Spotify.Extensions
     {
         private static Regex spotifyPlaylistIdPattern = new Regex(@"playlist[\/|:](.{22})", RegexOptions.Compiled);
 
-        public static FullPlaylist GetPlaylistByUrl(this SpotifyWebAPI api, string url)
+        public static FullPlaylist? GetPlaylistByUrl(this SpotifyWebAPI api, string url)
         {
             var id = ParseSpotifyIdFromUrl(url);
             if (id is null) { return null; }
@@ -16,7 +16,7 @@ namespace Youtube2Mp3.Spotify.Extensions
             return api.GetPlaylist(id);
         }
 
-        public static string ParseSpotifyIdFromUrl(string url)
+        public static string? ParseSpotifyIdFromUrl(string url)
         {
             if (url is null || !spotifyPlaylistIdPattern.IsMatch(url)) { return null; }
             return spotifyPlaylistIdPattern.Match(url).Groups[1].Value;

--- a/src/Youtube2Mp3.Spotify/SpotifyTrackRepository.cs
+++ b/src/Youtube2Mp3.Spotify/SpotifyTrackRepository.cs
@@ -13,7 +13,7 @@ namespace Youtube2Mp3.Spotify
 {
     public class SpotifyTrackRepository : ITrackRespository
     {
-        private SpotifyWebAPI _webApi;
+        private SpotifyWebAPI? _webApi;
         private SpotifyAuth _auth = new SpotifyAuth();
 
         public void InitializeSpotifyAuth(string clientId, string clientSecret)

--- a/src/Youtube2Mp3.Spotify/Youtube2Mp3.Spotify.csproj
+++ b/src/Youtube2Mp3.Spotify/Youtube2Mp3.Spotify.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Youtube2Mp3.Tests/SpotifyServiceTests.cs
+++ b/src/Youtube2Mp3.Tests/SpotifyServiceTests.cs
@@ -11,7 +11,7 @@ namespace Youtube2Mp3.Tests
         [InlineData(" ")]
         public void ShouldReturnNullIfEmptyUrl(string input)
         {
-            string expected = null!;
+            string? expected = null;
             var actual = SpotifyClientExtensions.ParseSpotifyIdFromUrl(input);
 
             Assert.Equal(expected, actual);

--- a/src/Youtube2Mp3.Tests/SpotifyServiceTests.cs
+++ b/src/Youtube2Mp3.Tests/SpotifyServiceTests.cs
@@ -11,7 +11,7 @@ namespace Youtube2Mp3.Tests
         [InlineData(" ")]
         public void ShouldReturnNullIfEmptyUrl(string input)
         {
-            string expected = null;
+            string expected = null!;
             var actual = SpotifyClientExtensions.ParseSpotifyIdFromUrl(input);
 
             Assert.Equal(expected, actual);

--- a/src/Youtube2Mp3.Tests/Youtube2Mp3.Tests.csproj
+++ b/src/Youtube2Mp3.Tests/Youtube2Mp3.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Youtube2Mp3.Youtube/Services/YoutubeStreamRepository.cs
+++ b/src/Youtube2Mp3.Youtube/Services/YoutubeStreamRepository.cs
@@ -98,7 +98,7 @@ namespace Youtube2Mp3.Youtube.Services
 
             if (videoFilteredByDuration is null && shouldFallback) { return videos.FirstOrDefault(); }
 
-            return videoFilteredByDuration;
+            return videoFilteredByDuration!;
         }
     }
 }

--- a/src/Youtube2Mp3.Youtube/Youtube2Mp3.Youtube.csproj
+++ b/src/Youtube2Mp3.Youtube/Youtube2Mp3.Youtube.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
## Summary

This change enables [Nullable reference types](https://devblogs.microsoft.com/dotnet/nullable-reference-types-in-csharp/) and updates projects to use C# 8.

It also fixes all Nullable reference type warnings found in the project, and implements a couple of improvements like getting client secret from Environment rather than strings, or removing unused using directives.

## What exactly was done

- Enable C# 8 and Fix nullables (d46d77d, ecd1054)

- Remove unused using directives (bc08334)

- Use Environment for Client secrets (cd3f67d)

- Inject unused dependency (dd5297a)

- Use ternary return operator opportunity (d699daf)

## Additional notes

I think these changes improve the overall design. 😊 A bit of housekeeping never hurts, right? 😄 