### PR TITLE
Add new constructor to Track.cs

### DIFF
--- a/src/Youtube2Mp3.ConsoleUi/Services/YoutubeUI.cs
+++ b/src/Youtube2Mp3.ConsoleUi/Services/YoutubeUI.cs
@@ -26,7 +26,7 @@ namespace Youtube2Mp3.ConsoleUi.Services
 
         public async Task SearchYoutubeTest()
         {
-            var searchTrack = new Track("SuperNova", new[] { "Mr Hudson" }, 0);
+            var searchTrack = new Track("SuperNova", "Mr Hudson", 0);
             var results = await _streamRepository.SearchAsync(searchTrack);
 
             foreach (var result in results)

--- a/src/Youtube2Mp3.Core/Entities/Track.cs
+++ b/src/Youtube2Mp3.Core/Entities/Track.cs
@@ -16,6 +16,13 @@ namespace Youtube2Mp3.Core.Entities
             Duration = GenerateTimeSpan(durationMilliSeconds);
         }
 
+        public Track(string title, string author, int durationMilliSeconds)
+        {
+            Title = title;
+            Authors = new[] { author };
+            Duration = GenerateTimeSpan(durationMilliSeconds);
+        }
+
         private TimeSpan GenerateTimeSpan(int durationMilliSeconds)
             => TimeSpan.FromMilliseconds(durationMilliSeconds);
     }


### PR DESCRIPTION
I quickly made a new constructor to `Track.cs`.
This constructor is there for songs that only have one artist, instead of having to create an `array` of one `string` (artist) manually, it'll now be done by said constructor.
This would make the code cleaner and more readable.